### PR TITLE
fix: Add client secret to the password auth strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drupal-graphql-client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Drupal client for GraphQL",
   "keywords": [
     "graphql",

--- a/src/authHandlers.ts
+++ b/src/authHandlers.ts
@@ -43,12 +43,14 @@ export const passwordHeaders = async (
   username: string,
   password: string,
   clientId: string,
+  clientSecret: string,
   fetcher: Config["fetcher"],
   headerKey?: string
 ) => {
   const formData = new FormData();
   formData.append("grant_type", "password");
   formData.append("client_id", clientId);
+  formData.append("client_secret", clientSecret);
   formData.append("username", username);
   formData.append("password", password);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,13 +26,14 @@ const calculateAuthHeaders = async <TAuth extends Auth["token_type"]>(
     }
   }
   if (type === "password") {
-    const { username, password, clientId, headerKey } =
+    const { username, password, clientId, headerKey, clientSecret } =
       options as Options<"password">;
     const headers = await passwordHeaders(
       uri,
       username,
       password,
       clientId,
+      clientSecret,
       fetcher,
       headerKey
     );
@@ -55,8 +56,36 @@ const calculateAuthHeaders = async <TAuth extends Auth["token_type"]>(
  * Generate a drupal client with the given auth and config
  * @param uri The uri of the drupal site
  * @param auth The auth strategy to use
- * @param options The options for the auth strategy
+ * @param options {Config} The auth options
  * @param config The config for the client
+ *
+ * The type for the options is decided by the auth type
+ * @example
+ * const client = drupalClient(
+ *  "https://drupal.site",
+ * "client_credentials",
+ *  {
+ *    clientId: "client_id",
+ *    clientSecret: "client_secret",
+ *  },
+ * );
+ * 
+ * In the above example, you only need to provide the clientId and clientSecret
+ * because the auth type is "client_credentials" but if you set the auth type to
+ * "password" you would need to provide the username and password as well.
+ * 
+ * @example
+ * const client = drupalClient(
+ *  "https://drupal.site",
+ *  "password",
+ *  {
+ *    username: "username",
+ *    password: "password",
+ *    clientId: "client_id",
+ *    clientSecret: "client_secret",
+ *   }
+ * );
+ * 
  *
  **/
 const drupalGraphqlClient = async <TAuth extends Auth["token_type"]>(
@@ -68,12 +97,7 @@ const drupalGraphqlClient = async <TAuth extends Auth["token_type"]>(
   }
 ) => {
   const { fetcher } = config;
-  const headers = await calculateAuthHeaders(
-    uri,
-    type,
-    options,
-    fetcher
-  );
+  const headers = await calculateAuthHeaders(uri, type, options, fetcher);
   if (!headers) {
     throw new Error("Unable to fetch auth headers");
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,12 +2,14 @@ type OptionsShared = {
   headerKey?: string;
 };
 
+type ClientOptions = OptionsShared & {
+  clientId: string;
+  clientSecret: string;
+};
+
 type ClientCredentialsOAuth = {
   token_type: "client_credentials";
-  options: {
-    clientId: string;
-    clientSecret: string;
-  } & OptionsShared;
+  options: ClientOptions;
 };
 
 type PasswordOAuth = {
@@ -15,8 +17,7 @@ type PasswordOAuth = {
   options: {
     username: string;
     password: string;
-    clientId: string;
-  } & OptionsShared;
+  } & ClientOptions;
 };
 
 type TokenAuth = {


### PR DESCRIPTION
# What does this PR do?
- Adds clientSecret parameter on the options when the auth strategy is Password
- Moves the client options to a separated type definition
- Improve the JSDoc for the drupalGraphqlClient function according to the strategies that we have now

# Resources
Based on this documentation: https://www.oauth.com/oauth2-servers/access-tokens/password-grant/